### PR TITLE
Add initiator type to generated diagram

### DIFF
--- a/har.go
+++ b/har.go
@@ -90,6 +90,12 @@ type Request struct {
 	Postdata    Content    `json:"postData"`
 }
 
+// Initiator represents information about the initiator of the request which
+// caused the Entry
+type Initiator struct {
+	Type string `json:"type"`
+}
+
 // Entry represents a single entry in the network log
 type Entry struct {
 	Pageref         string    `json:"pageref"`
@@ -102,6 +108,7 @@ type Entry struct {
 	Connection      string    `json:"connection,omitempty"`
 	Cache           Cache     `json:"cache,omitempty"`
 	Request         Request   `json:"request,omitempty"`
+	Initiator       Initiator `json:"_initiator,omitempty"`
 }
 
 // Entries is a group of entries

--- a/har_test.go
+++ b/har_test.go
@@ -16,6 +16,8 @@ var (
 	simpleExample string
 	//go:embed test/reference/plantuml/multipage-example.puml
 	multipageExample string
+	//go:embed test/reference/plantuml/initiator-example.puml
+	initiatorExample string
 )
 
 func TestCreatesHarFromGooglePage(t *testing.T) {
@@ -113,6 +115,61 @@ func TestDrawHar_MultiPage(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, output.String(), multipageExample)
+}
+
+func TestDrawHar_InitiatorTypes(t *testing.T) {
+	har := hoofli.Har{
+		Log: hoofli.Log{
+			Pages: []hoofli.Page{{
+				ID:    "page-1",
+				Title: "Example",
+			}},
+			Entries: []hoofli.Entry{
+				{
+					// unspecified _initiator
+					Pageref: "page-1",
+					Request: hoofli.Request{
+						Method: "GET",
+						URL:    "https://example.com/page-1",
+					},
+					Response: hoofli.Response{Status: 200},
+				},
+				{
+					Initiator: hoofli.Initiator{Type: "script"},
+					Pageref:   "page-1",
+					Request: hoofli.Request{
+						Method: "GET",
+						URL:    "https://example.com/page-1",
+					},
+					Response: hoofli.Response{Status: 200},
+				},
+				{
+					Initiator: hoofli.Initiator{Type: "renderer"},
+					Pageref:   "page-1",
+					Request: hoofli.Request{
+						Method: "GET",
+						URL:    "https://example.com/page-1",
+					},
+					Response: hoofli.Response{Status: 200},
+				},
+				{
+					Initiator: hoofli.Initiator{Type: "other"},
+					Pageref:   "page-1",
+					Request: hoofli.Request{
+						Method: "GET",
+						URL:    "https://example.com/page-1",
+					},
+					Response: hoofli.Response{Status: 200},
+				},
+			},
+		},
+	}
+
+	var output bytes.Buffer
+	err := har.Draw(&output)
+
+	require.NoError(t, err)
+	require.Equal(t, output.String(), initiatorExample)
 }
 
 func TestEntriesURLFilter_FixedPattern(t *testing.T) {

--- a/plantuml.go
+++ b/plantuml.go
@@ -35,3 +35,20 @@ func (h *Har) Draw(w io.Writer) error {
 	fmt.Fprintln(w, "@enduml")
 	return nil
 }
+
+// InitiatorTypeToColor converts the value found in
+// log.entries[]._initiator.type to a drawable color for plantuml. If the type
+// is not known yet, it will be rendered in the color specified as defaultColor.
+func InitiatorTypeToColor(strType string) string {
+	const defaultColor = "black"
+	colors := map[string]string{
+		"script":   "red",
+		"renderer": "blue",
+		"other":    "green",
+	}
+	out, ok := colors[strType]
+	if !ok {
+		return defaultColor
+	}
+	return out
+}

--- a/plantuml.go
+++ b/plantuml.go
@@ -21,7 +21,8 @@ func (h *Har) Draw(w io.Writer) error {
 				if parsedURL, err := url.Parse(dest); err == nil {
 					dest = parsedURL.Host
 				}
-				fmt.Fprintf(w, "Browser->\"%s\" ++ : %s %s\n",
+				fmt.Fprintf(w, "Browser-[#%s]->\"%s\" ++ : %s %s\n",
+					InitiatorTypeToColor(h.Log.Entries[i].Initiator.Type),
 					dest,
 					h.Log.Entries[i].Request.Method,
 					h.Log.Entries[i].Request.URL,

--- a/plantuml_test.go
+++ b/plantuml_test.go
@@ -1,0 +1,32 @@
+package hoofli
+
+import "testing"
+
+func TestTypeToColor(t *testing.T) {
+	type args struct {
+		strType string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Known type",
+			args: args{strType: "renderer"},
+			want: "blue",
+		},
+		{
+			name: "Unknown type",
+			args: args{strType: "spaceship"},
+			want: "black",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := InitiatorTypeToColor(tt.args.strType); got != tt.want {
+				t.Errorf("InitiatorTypeToColor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/reference/plantuml/initiator-example.puml
+++ b/test/reference/plantuml/initiator-example.puml
@@ -12,6 +12,7 @@ Browser-[#blue]->"example.com" ++ : GET https://example.com/page-1
 return 200
 Browser-[#green]->"example.com" ++ : GET https://example.com/page-1
 return 200
+note over Browser: Connection color represents initiator type:\n<font color=black> (black)</font>\n<font color=red>script (red)</font>\n<font color=blue>renderer (blue)</font>\n<font color=green>other (green)</font>
 deactivate Browser
 
 @enduml

--- a/test/reference/plantuml/initiator-example.puml
+++ b/test/reference/plantuml/initiator-example.puml
@@ -1,0 +1,17 @@
+@startuml
+
+participant Browser
+
+->Browser : Example
+activate Browser
+Browser-[#black]->"example.com" ++ : GET https://example.com/page-1
+return 200
+Browser-[#red]->"example.com" ++ : GET https://example.com/page-1
+return 200
+Browser-[#blue]->"example.com" ++ : GET https://example.com/page-1
+return 200
+Browser-[#green]->"example.com" ++ : GET https://example.com/page-1
+return 200
+deactivate Browser
+
+@enduml

--- a/test/reference/plantuml/multipage-example.puml
+++ b/test/reference/plantuml/multipage-example.puml
@@ -4,12 +4,12 @@ participant Browser
 
 ->Browser : Example
 activate Browser
-Browser->"example.com" ++ : GET https://example.com/page-1
+Browser-[#black]->"example.com" ++ : GET https://example.com/page-1
 return 200
 deactivate Browser
 ->Browser : Another Example
 activate Browser
-Browser->"example.com" ++ : GET https://example.com/page-2
+Browser-[#black]->"example.com" ++ : GET https://example.com/page-2
 return 200
 deactivate Browser
 

--- a/test/reference/plantuml/simple-example.puml
+++ b/test/reference/plantuml/simple-example.puml
@@ -4,7 +4,7 @@ participant Browser
 
 ->Browser : Example
 activate Browser
-Browser->"example.com" ++ : GET https://example.com/page-1
+Browser-[#black]->"example.com" ++ : GET https://example.com/page-1
 return 200
 deactivate Browser
 


### PR DESCRIPTION
# Description

Color connections based on the value of `log.entries[]._initiator.type`

Relates to issue #9 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
_see checklist below_

# How Has This Been Tested?

- [x] Running existing tests
- [x] Created new tests

# Checklist:

- [ ] My code has been linted (`make lint`)
_I tried, but 4 linters are outdated, three of them without replacement. I'm optimistic and hope GoLand did a good job here_
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
_I've took the liberty to check this box as there was no documentation to add to and considered my change small enough to not require full documentation apart from the legend added to the generated puml code._
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch to include the latest changes from `master`

---
I'm participating in Hacktoberfest 2022. If you like this PR, I'd be glad if you could add the hacktoberfest-accepted label to it and help me reach my goal :)
