### PR TITLE
Fix issue 12

### DIFF
--- a/har_test.go
+++ b/har_test.go
@@ -18,6 +18,8 @@ var (
 	multipageExample string
 	//go:embed test/reference/plantuml/initiator-example.puml
 	initiatorExample string
+	//go:embed test/reference/plantuml/some-initiator-example.puml
+	someInitiatorExample string
 )
 
 func TestCreatesHarFromGooglePage(t *testing.T) {
@@ -170,6 +172,54 @@ func TestDrawHar_InitiatorTypes(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, output.String(), initiatorExample)
+}
+
+// This test ensures that the legend does only render the initiator types which
+// were actually used in the HAR file
+func TestDrawHar_SomeInitiatorTypes(t *testing.T) {
+	har := hoofli.Har{
+		Log: hoofli.Log{
+			Pages: []hoofli.Page{{
+				ID:    "page-1",
+				Title: "Example",
+			}},
+			Entries: []hoofli.Entry{
+				{
+					// unspecified _initiator
+					Pageref: "page-1",
+					Request: hoofli.Request{
+						Method: "GET",
+						URL:    "https://example.com/page-1",
+					},
+					Response: hoofli.Response{Status: 200},
+				},
+				{
+					Initiator: hoofli.Initiator{Type: "script"},
+					Pageref:   "page-1",
+					Request: hoofli.Request{
+						Method: "GET",
+						URL:    "https://example.com/page-1",
+					},
+					Response: hoofli.Response{Status: 200},
+				},
+				{
+					Initiator: hoofli.Initiator{Type: "other"},
+					Pageref:   "page-1",
+					Request: hoofli.Request{
+						Method: "GET",
+						URL:    "https://example.com/page-1",
+					},
+					Response: hoofli.Response{Status: 200},
+				},
+			},
+		},
+	}
+
+	var output bytes.Buffer
+	err := har.Draw(&output)
+
+	require.NoError(t, err)
+	require.Equal(t, output.String(), someInitiatorExample)
 }
 
 func TestEntriesURLFilter_FixedPattern(t *testing.T) {

--- a/plantuml.go
+++ b/plantuml.go
@@ -11,7 +11,12 @@ func (h *Har) Draw(w io.Writer) error {
 	// initiatorTypesUsed stores the used initiator types for rendering the
 	// correct legend at the end. Using a map over a list gives us automatic
 	// deduplication.
-	initiatorTypesUsed := map[string]bool{}
+	initiatorTypesUsed := map[string]bool{
+		"script":   false,
+		"renderer": false,
+		"other":    false,
+		"":         false,
+	}
 	fmt.Fprintln(w, "@startuml")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "participant Browser")
@@ -37,7 +42,7 @@ func (h *Har) Draw(w io.Writer) error {
 			}
 		}
 		// add a note explaining the colors of the connections
-		if len(initiatorTypesUsed) > 1 {
+		if shouldRenderLegend(initiatorTypesUsed) {
 			fmt.Fprintf(w, "note over Browser: Connection color represents initiator type:")
 			for t, _ := range initiatorTypesUsed {
 				color := InitiatorTypeToColor(t)
@@ -67,4 +72,16 @@ func InitiatorTypeToColor(strType string) string {
 		return defaultColor
 	}
 	return out
+}
+
+// shouldRenderLegend decides if the legend explaining the initiator types
+// should be rendered. It will decide to render the legend if at least one
+// initiator type other than the "unspecified" type was used.
+func shouldRenderLegend(initiatorTypesUsed map[string]bool) bool {
+	for initiatorType, wasUsed := range initiatorTypesUsed {
+		if initiatorType != "" && wasUsed {
+			return true
+		}
+	}
+	return false
 }

--- a/plantuml.go
+++ b/plantuml.go
@@ -17,6 +17,7 @@ func (h *Har) Draw(w io.Writer) error {
 		"other":    false,
 		"":         false,
 	}
+	initiatorTypeOrder := []string{"script", "renderer", "other"}
 	fmt.Fprintln(w, "@startuml")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "participant Browser")
@@ -44,7 +45,11 @@ func (h *Har) Draw(w io.Writer) error {
 		// add a note explaining the colors of the connections
 		if shouldRenderLegend(initiatorTypesUsed) {
 			fmt.Fprintf(w, "note over Browser: Connection color represents initiator type:")
-			for t, _ := range initiatorTypesUsed {
+			for _, t := range initiatorTypeOrder {
+				if initiatorTypesUsed[t] == false {
+					// skip unused initiator type
+					continue
+				}
 				color := InitiatorTypeToColor(t)
 				fmt.Fprintf(w, "\\n<font color=%s>%s (%s)</font>", color, t, color)
 			}

--- a/plantuml_test.go
+++ b/plantuml_test.go
@@ -30,3 +30,42 @@ func TestTypeToColor(t *testing.T) {
 		})
 	}
 }
+
+func Test_shouldRenderLegend(t *testing.T) {
+	type args struct {
+		initiatorTypesUsed map[string]bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Only unspecified type used",
+			args: args{map[string]bool{
+				"script":   false,
+				"renderer": false,
+				"other":    false,
+				"":         true,
+			}},
+			want: false,
+		},
+		{
+			name: "Unspecified and renderer used",
+			args: args{map[string]bool{
+				"script":   false,
+				"renderer": true,
+				"other":    false,
+				"":         true,
+			}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRenderLegend(tt.args.initiatorTypesUsed); got != tt.want {
+				t.Errorf("shouldRenderLegend() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/reference/plantuml/some-initiator-example.puml
+++ b/test/reference/plantuml/some-initiator-example.puml
@@ -8,11 +8,9 @@ Browser-[#black]->"example.com" ++ : GET https://example.com/page-1
 return 200
 Browser-[#red]->"example.com" ++ : GET https://example.com/page-1
 return 200
-Browser-[#blue]->"example.com" ++ : GET https://example.com/page-1
-return 200
 Browser-[#green]->"example.com" ++ : GET https://example.com/page-1
 return 200
-note over Browser: Connection color represents initiator type:\n<font color=red>script (red)</font>\n<font color=blue>renderer (blue)</font>\n<font color=green>other (green)</font>
+note over Browser: Connection color represents initiator type:\n<font color=red>script (red)</font>\n<font color=green>other (green)</font>
 deactivate Browser
 
 @enduml


### PR DESCRIPTION
# Description

Changed the way used initiator types are tracked. The map `initiatorTypesUsed` is no longer filled on the fly but is defined before looping over log entries. The slice `initiatorTypeOrder` is ensuring the order when rendering the legend. This also stabilizes the test since the order of the initiator types is now predictable

Fixes #12 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Running existing tests _even multiple times with cleaning the cache_ (`go clean -testcache`)
- [x] Created new tests _for newly added logic_

# Checklist:

- [x] My code has been linted (`make lint`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch to include the latest changes from `master`

----

I'm participating in Hacktoberfest 2022. If you like this PR, I'd be glad if you could add the hacktoberfest-accepted label to it and help me reach my goal :)