### PR TITLE
Show blocked requests properly

### DIFF
--- a/har_test.go
+++ b/har_test.go
@@ -18,6 +18,8 @@ var (
 	multipageExample string
 	//go:embed test/reference/plantuml/initiator-example.puml
 	initiatorExample string
+	//go:embed test/reference/plantuml/canceled-example.puml
+	canceledExample string
 )
 
 func TestCreatesHarFromGooglePage(t *testing.T) {
@@ -70,6 +72,37 @@ func TestDrawHar_SinglePage(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, output.String(), simpleExample)
+}
+
+func TestDrawHar_Canceled_Example(t *testing.T) {
+	har := hoofli.Har{
+		Log: hoofli.Log{
+			Pages: []hoofli.Page{
+				{
+					ID:    "page-1",
+					Title: "Example",
+				},
+			},
+			Entries: []hoofli.Entry{
+				{
+					Pageref: "page-1",
+					Request: hoofli.Request{
+						Method: "GET",
+						URL:    "https://example.com/page-1",
+					},
+					Response: hoofli.Response{
+						Status: 0,
+					},
+				},
+			},
+		},
+	}
+
+	var output bytes.Buffer
+	err := har.Draw(&output)
+
+	require.NoError(t, err)
+	require.Equal(t, canceledExample, output.String())
 }
 
 func TestDrawHar_MultiPage(t *testing.T) {

--- a/plantuml.go
+++ b/plantuml.go
@@ -25,13 +25,24 @@ func (h *Har) Draw(w io.Writer) error {
 				if parsedURL, err := url.Parse(dest); err == nil {
 					dest = parsedURL.Host
 				}
-				fmt.Fprintf(w, "Browser-[#%s]->\"%s\" ++ : %s %s\n",
+				requestWasBlocked := h.Log.Entries[i].Response.Status == 0
+				connectorTip := ">"
+				if requestWasBlocked {
+					// a "Browser-x server" connector needs a space after the x
+					connectorTip = "x "
+				}
+
+				fmt.Fprintf(w, "Browser-[#%s]-%s\"%s\" ++ : %s %s\n",
 					InitiatorTypeToColor(h.Log.Entries[i].Initiator.Type),
+					connectorTip,
 					dest,
 					h.Log.Entries[i].Request.Method,
 					h.Log.Entries[i].Request.URL,
 				)
-				fmt.Fprintf(w, "return %d\n", h.Log.Entries[i].Response.Status)
+				if !requestWasBlocked {
+					// only draw the return message when the request was not blocked
+					fmt.Fprintf(w, "return %d\n", h.Log.Entries[i].Response.Status)
+				}
 				// remember we used an initiator of this type
 				initiatorTypesUsed[h.Log.Entries[i].Initiator.Type] = true
 			}

--- a/test/reference/plantuml/canceled-example.puml
+++ b/test/reference/plantuml/canceled-example.puml
@@ -1,0 +1,10 @@
+@startuml
+
+participant Browser
+
+->Browser : Example
+activate Browser
+Browser-[#black]-x "example.com" ++ : GET https://example.com/page-1
+deactivate Browser
+
+@enduml


### PR DESCRIPTION
# Description

This PR adds a new connection type `Alice -x Bob` which represents a request which was cancelled before it reaches Bob.

Fixes #13 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Running existing tests
- [x] Created new tests

# Checklist:

- [x] My code has been linted (`make lint`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch to include the latest changes from `master`

----
I think adding an explanation what a `A -x B` connection represents should be documented, but I'm unsure about the form. Modifying the code which draws the legend might lead to merge conflicts with the changes on PR #14 
